### PR TITLE
Add helper for dynamic directory

### DIFF
--- a/src/BashCommand.php
+++ b/src/BashCommand.php
@@ -42,7 +42,7 @@ class BashCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $workspaceCommand = 'cd laradock && docker-compose exec ';
+        $workspaceCommand = 'cd ' . Helpers::getLaradockDirectoryName() . ' && docker-compose exec ';
         if (!$input->getOption('root')) {
             $workspaceCommand .= '--user=laradock ';
         }

--- a/src/ConfigCommand.php
+++ b/src/ConfigCommand.php
@@ -35,7 +35,7 @@ class ConfigCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $configCommand = 'cd laradock && vim docker-compose.yml';
+        $configCommand = 'cd ' . Helpers::getLaradockDirectoryName() . ' && vim docker-compose.yml';
 
         passthru($configCommand);
     }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: rob
+ * Date: 03/06/2017
+ * Time: 18:00
+ */
+
+namespace LorinLee\LaradockCli\Console;
+
+
+class Helpers
+{
+
+    /**
+     * @return string
+     */
+    public static function getLaradockDirectoryName() {
+        $full_path = getcwd();
+        $full_path_parts = explode('/', $full_path);
+        $directory_name = end($full_path_parts);
+        return $directory_name . '_laradock';
+    }
+
+}

--- a/src/InitCommand.php
+++ b/src/InitCommand.php
@@ -61,7 +61,8 @@ class InitCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (file_exists('laradock') && is_dir('laradock')) {
+        $dirname = Helpers::getLaradockDirectoryName();
+        if (file_exists($dirname) && is_dir($dirname)) {
             throw new RuntimeException('laradock exists');
         }
 
@@ -73,7 +74,7 @@ class InitCommand extends Command
             $initCommand = 'git submodule add';
         }
 
-        $process = new Process($initCommand . ' ' . $repo);
+        $process = new Process($initCommand . ' ' . $repo . ' ' . $dirname);
 
         if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
             $process->setTty(true);
@@ -86,7 +87,7 @@ class InitCommand extends Command
         });
 
         $output->writeln('<comment>Initializing default config.</comment>');
-        $process = new Process('cd laradock && cp env-example .env');
+        $process = new Process('cd ' . $dirname . ' && cp env-example .env');
         $process->run();
 
         $output->writeln('<comment>Done.</comment>');

--- a/src/PsCommand.php
+++ b/src/PsCommand.php
@@ -29,7 +29,7 @@ class PsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $psCommand = 'cd laradock && docker-compose ps';
+        $psCommand = 'cd ' . Helpers::getLaradockDirectoryName() . ' && docker-compose ps';
 
         $process = new Process($psCommand);
 

--- a/src/RepoCommand.php
+++ b/src/RepoCommand.php
@@ -8,9 +8,7 @@
 
 namespace LorinLee\LaradockCli\Console;
 
-use LorinLee\LaradockCli\Console\RepoConfigManager;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/StopCommand.php
+++ b/src/StopCommand.php
@@ -43,7 +43,7 @@ class StopCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $stopCommand = 'cd laradock && docker-compose stop';
+        $stopCommand = 'cd ' . Helpers::getLaradockDirectoryName() . ' && docker-compose stop';
 
         $containers = $input->getArgument('containers');
         if (count($containers) === 0) {

--- a/src/UpCommand.php
+++ b/src/UpCommand.php
@@ -72,7 +72,7 @@ class UpCommand extends Command
 
         $output->writeln('<info>Starting ' . $upParameter . '</info>');
 
-        $process = new Process('cd laradock && docker-compose up -d ' . $upParameter);
+        $process = new Process('cd ' . Helpers::getLaradockDirectoryName() . ' && docker-compose up -d ' . $upParameter);
 
         if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
             $process->setTty(true);


### PR DESCRIPTION
Since when we are using laradock using a proxy, the folder 'laradock' should be unique.

This is not a failsafe way, but it avoids it from being just 'laradock'